### PR TITLE
Support scrollable text

### DIFF
--- a/js/source/jquery.smoothTouchScroll.js
+++ b/js/source/jquery.smoothTouchScroll.js
@@ -141,18 +141,22 @@
 		**********************************************************/
 		recalculateScrollableArea: function () {
 
-			var tempScrollableAreaWidth = 0, foundStartAtElement = false, o = this.options, el = this.element;
+			var tempScrollableAreaWidth = 0, foundStartAtElement = false, o = this.options, el = this.element, children = el.data("scrollableArea").children();
 
 			// Add up the total width of all the items inside the scrollable area
-			el.data("scrollableArea").children().each(function () {
-				// Check to see if the current element in the loop is the one where the scrolling should start
-				if ((o.startAtElementId.length > 0) && (($(this).attr("id")) === o.startAtElementId)) {
-					el.data("startingPosition", tempScrollableAreaWidth);
-					foundStartAtElement = true;
-				}
-				tempScrollableAreaWidth = tempScrollableAreaWidth + $(this).outerWidth(true);
-
-			});
+			if (children.length) {
+				el.data("scrollableArea").children().each(function () {
+					// Check to see if the current element in the loop is the one where the scrolling should start
+					if ((o.startAtElementId.length > 0) && (($(this).attr("id")) === o.startAtElementId)) {
+						el.data("startingPosition", tempScrollableAreaWidth);
+						foundStartAtElement = true;
+					}
+					tempScrollableAreaWidth = tempScrollableAreaWidth + $(this).outerWidth(true);
+				});
+			} else {
+				// Doesn't have children, so calculate width of scollableAread
+				tempScrollableAreaWidth += el.data("scrollableArea").outerWidth(true);
+			}
 
 			// If the element with the ID specified by startAtElementId
 			// is not found, reset it


### PR DESCRIPTION
Had issues when tried to make centre aligned text inside a div scrollable. Other option is to have a div inside a div but prefer not to have redundant elements on the page :)

What would happen is because the div didn't have any children the width will get calculated at 0 and the alignment would screw up... As in the (very simplified) example below I had a few elements which were same and they had to get smooth scroll if they were too long, otherwise should just stay centred.

If you test it you'll see that the short `.text` element will get aligned to the left because the width will be set to `0px`. This commit fixes this.

For example:

``` css
.text {
  width: 150px;
  white-space: nowrap;
  text-align: center;
  margin: 0 auto;
  font-size: 16px;
  font-family: Arial;
}
```

``` html
<div class="text">I want to get scrolled properly even though I'm just simple text inside a simple div and the div doesn't have any children</div>
<div class="text">I am short :)</div>
```

``` javascript
$(".text").smoothTouchScroll();
```

Thanks for a cool little plugin ;)
